### PR TITLE
made navbar translucent

### DIFF
--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -27,7 +27,7 @@ function NavBar ( {handlePress, selectedLocation, setSelectedLocation, distance}
             width: '100%',
             height: height,
             bottom: 0,
-            backgroundColor: 'grey'
+            backgroundColor: 'rgba(52, 52, 52, 0.85)'
         }
     })
     


### PR DESCRIPTION
Made navbar slightly translucent so it doesn't obscure the map view so much when pulled up. Easy enough to make less or more transparent than this!

[](url)

![Screen Shot 2021-05-14 at 3 19 20 PM](https://user-images.githubusercontent.com/69255563/118318746-cd40ce00-b4c7-11eb-9cc9-b1d22511ca0d.png)
